### PR TITLE
Fix index error in track assignment

### DIFF
--- a/reid_pipeline.py
+++ b/reid_pipeline.py
@@ -631,6 +631,10 @@ class EnhancedReIDPipeline:
         for i, track_id in enumerate(detections.tracker_id):
             if track_id < 0:
                 continue
+
+            if i >= len(reid_features):
+                print(f"⚠️ Missing ReID feature for detection index {i}, skipping")
+                continue
             
             # STABILITY CHECK: Skip if track is locked in cooling period
             if self.stability_manager.is_track_locked(track_id):


### PR DESCRIPTION
## Summary
- fix IndexError in `intelligent_track_assignment` when reid feature list is shorter than detections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: cv2, pycocotools)*

------
https://chatgpt.com/codex/tasks/task_e_68505bb0ef68832dbce801b5f04cb478